### PR TITLE
🚀 어드민 회원가입,로그인 ,인증미들웨어 ,  티켓발급, 내티켓 확인 작업

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ const express = require('express');
 const app = express();
 const mongoose = require('mongoose');
 const cors = require('cors');
-const { TestRouter } = require('./routes');
+const { TestRouter, RoutePostTickets, RouteGetTickets } = require('./routes');
 const { customResponse } = require('./utils/customResponse');
 const { errorHandler, errorLoger } = require('./middleware');
 const dotenv = require('dotenv');
@@ -41,6 +41,8 @@ const server = async () => {
     app.use(express.json());
 
     app.use(TestRouter);
+    app.use(RoutePostTickets);
+    app.use(RouteGetTickets);
 
     app.use(errorLoger);
     app.use(errorHandler);

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,13 @@ const express = require('express');
 const app = express();
 const mongoose = require('mongoose');
 const cors = require('cors');
-const { TestRouter, RoutePostTickets, RouteGetTickets } = require('./routes');
+const {
+  TestRouter,
+  RoutePostTickets,
+  RouteGetTickets,
+  RouteAdminlogin,
+  RouteAdminRegister
+} = require('./routes');
 const { customResponse } = require('./utils/customResponse');
 const { errorHandler, errorLoger } = require('./middleware');
 const dotenv = require('dotenv');
@@ -43,6 +49,8 @@ const server = async () => {
     app.use(TestRouter);
     app.use(RoutePostTickets);
     app.use(RouteGetTickets);
+    app.use(RouteAdminlogin);
+    app.use(RouteAdminRegister);
 
     app.use(errorLoger);
     app.use(errorHandler);

--- a/src/middleware/AdminAuthentication.js
+++ b/src/middleware/AdminAuthentication.js
@@ -1,0 +1,28 @@
+const { decodeToken } = require('../utils/decodeToken');
+const { AuthenticationError, CustomError } = require('../errors');
+const ErrorMessage = require('../errors/ErrorMessage');
+
+const AdminAuthentication = async (req, res, next) => {
+  try {
+    if (!req.headers.authorization) {
+      throw new AuthenticationError(null, ErrorMessage.TOKEN_NOT_EXIST);
+    }
+    const token = req.headers.authorization.split(' ')[1];
+    const decodedToken = await decodeToken(
+      token,
+      process.env.JWT_KEY_ADMIN_ACCESS
+    );
+
+    if (decodedToken) {
+      req.body.adminUser = decodedToken;
+    }
+    return next();
+  } catch (err) {
+    if (err instanceof CustomError) {
+      return next(err);
+    }
+    return next(new AuthenticationError(err, err));
+  }
+};
+
+module.exports = { AdminAuthentication };

--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -1,6 +1,7 @@
 module.exports = {
-  ...require("./validationCatch"),
-  ...require("./tokenAuthentication.js"),
-  ...require("./error-handler.js"),
-  ...require("./error-loger.js"),
+  ...require('./validationCatch'),
+  ...require('./tokenAuthentication.js'),
+  ...require('./error-handler.js'),
+  ...require('./error-loger.js'),
+  ...require('./AdminAuthentication.js')
 };

--- a/src/middleware/validationCatch.js
+++ b/src/middleware/validationCatch.js
@@ -1,9 +1,8 @@
-const { validationResult } = require("express-validator");
-const { ValidationError } = require("../errors");
+const { validationResult } = require('express-validator');
+const { ValidationError } = require('../errors');
 const validationCatch = (req, res, next) => {
   try {
     const result = validationResult(req);
-    console.log(result.isEmpty());
     if (!result.isEmpty()) {
       throw new ValidationError(null, result.errors);
     }

--- a/src/model/Ticket.js
+++ b/src/model/Ticket.js
@@ -17,6 +17,8 @@ const TicketSchema = new Schema(
     // 어드민 (공짜티켓관련)
     adminTicket: { type: Boolean, default: false },
 
+    accountName: { type: String },
+
     // 마지막으로 관리한 사람이 누군지.  populate 활용하세요.
     manager: { type: Schema.Types.ObjectId, ref: 'admin' }
   },

--- a/src/model/index.js
+++ b/src/model/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  ...require('./Ticket'),
+  ...require('./Admin')
+};

--- a/src/routes/RouteAdminRegister.js
+++ b/src/routes/RouteAdminRegister.js
@@ -1,0 +1,55 @@
+const express = require('express');
+// const axios = require("axios");
+const RouteAdminRegister = express.Router();
+const { validationCatch } = require('../middleware/validationCatch');
+const { body } = require('express-validator');
+const { ServerCommonError, CustomError } = require('../errors');
+const { Ticket } = require('../model');
+
+// accessToken 미들웨어가 만들어지면 accessToken 에서 받아오는 걸로 수정 예정입니다.
+RouteAdminRegister.get(
+  '/admin/register',
+  [
+    body('userId')
+      .isString()
+      .withMessage('문자열 이어야합니다.')
+      .isLength({ min: 3, max: 20 })
+      .withMessage('userId 길이는 3-20자이어야 합니다.'),
+    body('name')
+      .isString()
+      .withMessage('문자열 이어야합니다.')
+      .isLength({ min: 3, max: 3 })
+      .withMessage('name 길이는 3자이어야 합니다.'),
+    body('password')
+      .isString()
+      .withMessage('문자열 이어야합니다.')
+      .isLength({ min: 6, max: 30 })
+      .withMessage('password 길이는 6-30자이어야 합니다.')
+  ],
+  validationCatch,
+  async (req, res, next) => {
+    try {
+      // 추후 phoneNumber 는 accessToken 미들웨어에서 가져올 예정입니다./
+      const { userId, name, password } = req.query;
+      console.log(phoneNumber);
+
+      // 티켓 전체 수량 세기
+      const myTickets = await Ticket.find({
+        phoneNumber: phoneNumber
+      });
+
+      if (!myTickets.length) {
+        return res.custom400FailMessage('예매티켓없음');
+      }
+
+      return res.custom200SuccessData(myTickets);
+    } catch (err) {
+      if (err instanceof CustomError) {
+        return next(err);
+      }
+      return next(new ServerCommonError(err));
+    }
+  }
+);
+
+module.exports = { RouteAdminRegister };

--- a/src/routes/RouteAdminRegister.js
+++ b/src/routes/RouteAdminRegister.js
@@ -1,20 +1,22 @@
 const express = require('express');
-// const axios = require("axios");
 const RouteAdminRegister = express.Router();
 const { validationCatch } = require('../middleware/validationCatch');
 const { body } = require('express-validator');
 const { ServerCommonError, CustomError } = require('../errors');
-const { Ticket } = require('../model');
+const { Ticket, Admin } = require('../model');
+const { hash } = require('bcryptjs');
 
 // accessToken 미들웨어가 만들어지면 accessToken 에서 받아오는 걸로 수정 예정입니다.
-RouteAdminRegister.get(
+RouteAdminRegister.post(
   '/admin/register',
   [
     body('userId')
       .isString()
       .withMessage('문자열 이어야합니다.')
       .isLength({ min: 3, max: 20 })
-      .withMessage('userId 길이는 3-20자이어야 합니다.'),
+      .withMessage('userId 길이는 3-20자이어야 합니다.')
+      .matches(/^[A-Za-z0-9]+$/)
+      .withMessage('소문자 , 숫자만 가능합니다.'),
     body('name')
       .isString()
       .withMessage('문자열 이어야합니다.')
@@ -24,25 +26,48 @@ RouteAdminRegister.get(
       .isString()
       .withMessage('문자열 이어야합니다.')
       .isLength({ min: 6, max: 30 })
-      .withMessage('password 길이는 6-30자이어야 합니다.')
+      .withMessage('password 길이는 6-30자이어야 합니다.'),
+    body('gosrockCode')
+      .isString()
+      .withMessage('문자열 이어야합니다.')
+      .isLength({ min: 4, max: 4 })
+      .withMessage('gosrockCode 길이는 4자이어야 합니다.')
   ],
   validationCatch,
   async (req, res, next) => {
     try {
       // 추후 phoneNumber 는 accessToken 미들웨어에서 가져올 예정입니다./
-      const { userId, name, password } = req.query;
-      console.log(phoneNumber);
+      const { userId, name, password, gosrockCode } = req.body;
+      if (gosrockCode !== '1234') {
+        return res.custom400FailMessage('코드오류');
+      }
+      console.log(userId, name, password);
+      // 비밀번호 해쉬 암호화
 
-      // 티켓 전체 수량 세기
-      const myTickets = await Ticket.find({
-        phoneNumber: phoneNumber
-      });
+      const hashedPassword = await hash(password, 10);
+      const findAdmins = await Admin.aggregate([
+        {
+          $match: {
+            $or: [{ name: { $eq: name } }, { userId: { $eq: userId } }]
+          }
+        }
+      ]);
 
-      if (!myTickets.length) {
-        return res.custom400FailMessage('예매티켓없음');
+      if (findAdmins.length) {
+        return res.custom400FailMessage('중복가입');
       }
 
-      return res.custom200SuccessData(myTickets);
+      const newAdminUser = new Admin({
+        password: hashedPassword,
+        userId,
+        name
+      });
+
+      await newAdminUser.save();
+
+      console.log(newAdminUser);
+
+      return res.custom200SuccessData(newAdminUser);
     } catch (err) {
       if (err instanceof CustomError) {
         return next(err);

--- a/src/routes/RouteAdminlogin.js
+++ b/src/routes/RouteAdminlogin.js
@@ -1,41 +1,51 @@
 const express = require('express');
-// const axios = require("axios");
 const RouteAdminlogin = express.Router();
 const { validationCatch } = require('../middleware/validationCatch');
 const { body } = require('express-validator');
 const { ServerCommonError, CustomError } = require('../errors');
-const { Ticket } = require('../model');
-
+const { Admin } = require('../model');
+const { compare } = require('bcryptjs');
+const { adminAccessTokenGenerate } = require('../utils/jwtTokenGenerate');
 // accessToken 미들웨어가 만들어지면 accessToken 에서 받아오는 걸로 수정 예정입니다.
 RouteAdminlogin.post(
-  '/tickets',
+  '/admin/login',
   [
-    body('phoneNumber')
-      .matches(/^[0-9]+$/)
-      .withMessage('숫자만 들어와야합니다.')
-      .isLength({ min: 11, max: 11 })
-      .withMessage('전화번호 길이는 11자이어야 합니다.')
-
-      .matches(/^[a-z0-9]+$/)
-      .withMessage('소문자 , 숫자만 가능합니다.')
+    body('userId')
+      .isString()
+      .withMessage('문자열 이어야합니다.')
+      .isLength({ min: 3, max: 20 })
+      .withMessage('userId 길이는 3-20자이어야 합니다.')
+      .matches(/^[A-Za-z0-9]+$/)
+      .withMessage('소문자 , 숫자만 가능합니다.'),
+    body('password')
+      .isString()
+      .withMessage('문자열 이어야합니다.')
+      .isLength({ min: 6, max: 30 })
+      .withMessage('password 길이는 6-30자이어야 합니다.')
   ],
   validationCatch,
   async (req, res, next) => {
     try {
       // 추후 phoneNumber 는 accessToken 미들웨어에서 가져올 예정입니다./
-      const { phoneNumber } = req.body;
-      console.log(phoneNumber);
+      const { userId, password } = req.body;
 
       // 티켓 전체 수량 세기
-      const myTickets = await Ticket.find({
-        phoneNumber: phoneNumber
-      });
-
-      if (!myTickets.length) {
-        return res.custom400FailMessage('예매티켓없음');
+      const findAdmin = await Admin.findOne({ userId });
+      if (!findAdmin) {
+        return res.custom400FailMessage('아이디비밀번호오류');
       }
 
-      return res.custom200SuccessData(myTickets);
+      const isValid = await compare(password, findAdmin.password);
+      if (!isValid) {
+        return res.custom400FailMessage('아이디비밀번호오류');
+      }
+
+      const adminAccessToken = adminAccessTokenGenerate(findAdmin);
+
+      return res.custom200SuccessData({
+        adminUser: findAdmin,
+        adminAccessToken
+      });
     } catch (err) {
       if (err instanceof CustomError) {
         return next(err);

--- a/src/routes/RouteAdminlogin.js
+++ b/src/routes/RouteAdminlogin.js
@@ -7,20 +7,23 @@ const { ServerCommonError, CustomError } = require('../errors');
 const { Ticket } = require('../model');
 
 // accessToken 미들웨어가 만들어지면 accessToken 에서 받아오는 걸로 수정 예정입니다.
-RouteAdminlogin.get(
+RouteAdminlogin.post(
   '/tickets',
   [
-    query('phoneNumber')
+    body('phoneNumber')
       .matches(/^[0-9]+$/)
       .withMessage('숫자만 들어와야합니다.')
       .isLength({ min: 11, max: 11 })
       .withMessage('전화번호 길이는 11자이어야 합니다.')
+
+      .matches(/^[a-z0-9]+$/)
+      .withMessage('소문자 , 숫자만 가능합니다.')
   ],
   validationCatch,
   async (req, res, next) => {
     try {
       // 추후 phoneNumber 는 accessToken 미들웨어에서 가져올 예정입니다./
-      const { phoneNumber } = req.query;
+      const { phoneNumber } = req.body;
       console.log(phoneNumber);
 
       // 티켓 전체 수량 세기

--- a/src/routes/RouteAdminlogin.js
+++ b/src/routes/RouteAdminlogin.js
@@ -1,0 +1,45 @@
+const express = require('express');
+// const axios = require("axios");
+const RouteAdminlogin = express.Router();
+const { validationCatch } = require('../middleware/validationCatch');
+const { body } = require('express-validator');
+const { ServerCommonError, CustomError } = require('../errors');
+const { Ticket } = require('../model');
+
+// accessToken 미들웨어가 만들어지면 accessToken 에서 받아오는 걸로 수정 예정입니다.
+RouteAdminlogin.get(
+  '/tickets',
+  [
+    query('phoneNumber')
+      .matches(/^[0-9]+$/)
+      .withMessage('숫자만 들어와야합니다.')
+      .isLength({ min: 11, max: 11 })
+      .withMessage('전화번호 길이는 11자이어야 합니다.')
+  ],
+  validationCatch,
+  async (req, res, next) => {
+    try {
+      // 추후 phoneNumber 는 accessToken 미들웨어에서 가져올 예정입니다./
+      const { phoneNumber } = req.query;
+      console.log(phoneNumber);
+
+      // 티켓 전체 수량 세기
+      const myTickets = await Ticket.find({
+        phoneNumber: phoneNumber
+      });
+
+      if (!myTickets.length) {
+        return res.custom400FailMessage('예매티켓없음');
+      }
+
+      return res.custom200SuccessData(myTickets);
+    } catch (err) {
+      if (err instanceof CustomError) {
+        return next(err);
+      }
+      return next(new ServerCommonError(err));
+    }
+  }
+);
+
+module.exports = { RouteAdminlogin };

--- a/src/routes/RouteGetTickets.js
+++ b/src/routes/RouteGetTickets.js
@@ -21,7 +21,6 @@ RouteGetTickets.get(
     try {
       // 추후 phoneNumber 는 accessToken 미들웨어에서 가져올 예정입니다./
       const { phoneNumber } = req.query;
-      console.log(phoneNumber);
 
       // 티켓 전체 수량 세기
       const myTickets = await Ticket.find({

--- a/src/routes/RouteGetTickets.js
+++ b/src/routes/RouteGetTickets.js
@@ -1,0 +1,45 @@
+const express = require('express');
+// const axios = require("axios");
+const RouteGetTickets = express.Router();
+const { validationCatch } = require('../middleware/validationCatch');
+const { query, body } = require('express-validator');
+const { ServerCommonError, CustomError } = require('../errors');
+const { Ticket } = require('../model');
+
+// accessToken 미들웨어가 만들어지면 accessToken 에서 받아오는 걸로 수정 예정입니다.
+RouteGetTickets.get(
+  '/tickets',
+  [
+    query('phoneNumber')
+      .matches(/^[0-9]+$/)
+      .withMessage('숫자만 들어와야합니다.')
+      .isLength({ min: 11, max: 11 })
+      .withMessage('전화번호 길이는 11자이어야 합니다.')
+  ],
+  validationCatch,
+  async (req, res, next) => {
+    try {
+      // 추후 phoneNumber 는 accessToken 미들웨어에서 가져올 예정입니다./
+      const { phoneNumber } = req.query;
+      console.log(phoneNumber);
+
+      // 티켓 전체 수량 세기
+      const myTickets = await Ticket.find({
+        phoneNumber: phoneNumber
+      });
+
+      if (!myTickets.length) {
+        return res.custom400FailMessage('예매티켓없음');
+      }
+
+      return res.custom200SuccessData(myTickets);
+    } catch (err) {
+      if (err instanceof CustomError) {
+        return next(err);
+      }
+      return next(new ServerCommonError(err));
+    }
+  }
+);
+
+module.exports = { RouteGetTickets };

--- a/src/routes/RoutePostTickets.js
+++ b/src/routes/RoutePostTickets.js
@@ -1,0 +1,64 @@
+const express = require('express');
+// const axios = require("axios");
+const RoutePostTickets = express.Router();
+const { validationCatch } = require('../middleware/validationCatch');
+const { query, body } = require('express-validator');
+const { ServerCommonError, CustomError } = require('../errors');
+const { Ticket } = require('../model');
+RoutePostTickets.post(
+  '/tickets',
+  [
+    body('phoneNumber')
+      .matches(/^[0-9]+$/)
+      .withMessage('숫자만 들어와야합니다.')
+      .isLength({ min: 11, max: 11 })
+      .withMessage('전화번호 길이는 11자이어야 합니다.'),
+    body('ticketCount')
+      .isInt()
+      .withMessage('ticketCount 0이상 10이하의 정수로 필요합니다.'),
+    body('accountName').isString().withMessage('accountName 숫자로 필요합니다.')
+  ],
+  validationCatch,
+  async (req, res, next) => {
+    try {
+      // 추후 phoneNumber 는 accessToken 미들웨어에서 가져올 예정입니다./
+      const { phoneNumber, ticketCount, accountName } = req.body;
+      console.log(phoneNumber, ticketCount, accountName);
+
+      if (ticketCount <= 0 || ticketCount > 10) {
+        return res.custom400FailMessage('티켓수량오류');
+      }
+
+      let listOfTickets = [];
+      // 티켓 전체 수량 세기
+      const allTicketCount = await Ticket.find().countDocuments();
+
+      for (step = 0; step < ticketCount; step++) {
+        // 티켓 서버에서 발급
+        const ticket = new Ticket({
+          ticketNumber: allTicketCount + 1 + step,
+          accountName,
+          phoneNumber
+        });
+        listOfTickets.push(ticket);
+      }
+
+      // 병렬로 티켓 저장
+      await Promise.all(
+        listOfTickets.map(async ticket => {
+          await ticket.save();
+        })
+      );
+
+      return res.custom200SuccessData(listOfTickets);
+      // return res.json({ success: true, data: { user: '찬진' } });
+    } catch (err) {
+      if (err instanceof CustomError) {
+        return next(err);
+      }
+      return next(new ServerCommonError(err));
+    }
+  }
+);
+
+module.exports = { RoutePostTickets };

--- a/src/routes/RouteTest.js
+++ b/src/routes/RouteTest.js
@@ -4,6 +4,7 @@ const TestRouter = express.Router();
 const { validationCatch } = require('../middleware/validationCatch');
 const { query, body } = require('express-validator');
 const { ServerCommonError, CustomError } = require('../errors');
+const { AdminAuthentication } = require('../middleware');
 
 TestRouter.post(
   '/api/test',
@@ -27,7 +28,7 @@ TestRouter.post(
 
 TestRouter.get(
   '/api/test',
-
+  AdminAuthentication,
   // 미들 웨어 달아서 인증 먼저
   [
     // query("phonenumber")
@@ -37,8 +38,8 @@ TestRouter.get(
   validationCatch,
   async (req, res, next) => {
     try {
-      // const { decodedAccessToken } = req.body;
-      console.log('phone');
+      const { adminUser } = req.body;
+      console.log(adminUser);
       return res.json({ success: true, data: { user: '찬진' } });
     } catch (err) {
       if (err instanceof CustomError) {

--- a/src/routes/RouteTest.js
+++ b/src/routes/RouteTest.js
@@ -1,19 +1,21 @@
-const express = require("express");
+const express = require('express');
 // const axios = require("axios");
 const TestRouter = express.Router();
-const { validationCatch } = require("../middleware/validationCatch");
-const { query, body } = require("express-validator");
-const { ServerCommonError, CustomError, NaverSMSError } = require("../errors");
+const { validationCatch } = require('../middleware/validationCatch');
+const { query, body } = require('express-validator');
+const { ServerCommonError, CustomError } = require('../errors');
 
 TestRouter.post(
-  "/api/test",
-  [body("phonenumber").isString().withMessage("전화번호가 필요합니다.")],
+  '/api/test',
+  [body('name').isString().withMessage('name 필요합니다.')],
   validationCatch,
   async (req, res, next) => {
     try {
       const { phonenumber } = req.body;
-      console.log("phone", phonenumber);
-      return res.json({ success: true, data: { user: "찬진" } });
+      console.log('phone', phonenumber);
+
+      return res.custom200SuccessData({ user: '찬진' });
+      // return res.json({ success: true, data: { user: '찬진' } });
     } catch (err) {
       if (err instanceof CustomError) {
         return next(err);
@@ -24,7 +26,9 @@ TestRouter.post(
 );
 
 TestRouter.get(
-  "/api/test",
+  '/api/test',
+
+  // 미들 웨어 달아서 인증 먼저
   [
     // query("phonenumber")
     //   .isEmpty()
@@ -33,8 +37,9 @@ TestRouter.get(
   validationCatch,
   async (req, res, next) => {
     try {
-      console.log("phone");
-      return res.json({ success: true, data: { user: "찬진" } });
+      // const { decodedAccessToken } = req.body;
+      console.log('phone');
+      return res.json({ success: true, data: { user: '찬진' } });
     } catch (err) {
       if (err instanceof CustomError) {
         return next(err);

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,5 +1,7 @@
 module.exports = {
   ...require('./RouteTest'),
   ...require('./RoutePostTickets'),
-  ...require('./RouteGetTickets')
+  ...require('./RouteGetTickets'),
+  ...require('./RouteAdminRegister'),
+  ...require('./RouteAdminlogin')
 };

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,3 +1,5 @@
 module.exports = {
-  ...require("./RouteTest"),
+  ...require('./RouteTest'),
+  ...require('./RoutePostTickets'),
+  ...require('./RouteGetTickets')
 };

--- a/src/utils/jwtTokenGenerate.js
+++ b/src/utils/jwtTokenGenerate.js
@@ -33,4 +33,23 @@ const refreshTokenGenerate = user => {
   return userRefreshJwt;
 };
 
-module.exports = { accessTokenGenerate, refreshTokenGenerate };
+const adminAccessTokenGenerate = ({ userId, name, _id }) => {
+  const adminUserAccessJwt = jwt.sign(
+    {
+      _id: _id,
+      name: name,
+      userId: userId
+    },
+    process.env.JWT_KEY_ADMIN_ACCESS,
+    {
+      expiresIn: '1h'
+    }
+  );
+  return adminUserAccessJwt;
+};
+
+module.exports = {
+  accessTokenGenerate,
+  refreshTokenGenerate,
+  adminAccessTokenGenerate
+};

--- a/src/utils/jwtTokenGenerate.js
+++ b/src/utils/jwtTokenGenerate.js
@@ -10,7 +10,7 @@ const accessTokenGenerate = user => {
       profile_url: user.profile_url,
       status: user.status
     },
-    process.env.JWT_KEY_ACCESS,
+    process.env.JWT_KEY_MESSAGE,
     {
       expiresIn: '24h'
     }


### PR DESCRIPTION
-  내 티켓 발급하기 
#9 
#10 
내 티켓 발급하기에서는 userAccessToken이 필요한 api 들이지만 일단은 body 파라미터로 전화번호를 받아 작성하게 끔 만들었습니다.
추후 userAccessToken 의 발급과 미들웨어가 제작되면 req.body 로 user 의 정보를 받아 해당 전화번호로 찾고 , 티켓을 발급할 예정입니다.



 -  어드민 회원가입 , 로그인 ,인증미들웨어
#11 
#12 
#13 
어드민 회원가입 같은경우에는 고스락 고유 인증 코드 네자리 ( 테스트는 1234 ) 를 client에서 받아 가입하는 구조로 작성했고.
비밀번호는 bcryptjs 를 이용해서 암호화 했습니다.
회원가입 후 로그인을 해야 adminAccessToken 이 발급됩니다.

전부다 express-validator를 활용해서 적절하게 검증을 했습니다.
일요일날 문서작업 예정입니다.